### PR TITLE
Remove DOB with precision < 9

### DIFF
--- a/docs/leaders/albania/current.csv
+++ b/docs/leaders/albania/current.csv
@@ -20,4 +20,4 @@ Minister of State for Youth and Children,Bora Muzhaqi,Q109524653,2021-09-18,,,,,
 Speaker of the Parliament,Lindita Nikolla,Q15193651,2021-09-10,female,1965-10-22,,,Lindita Nikolla
 Mayor of Tirana,Erion Veliaj,Q16354049,2015-07-21,male,1979-12-17,,Erion Veliaj.jpg,Erion Veliaj
 Chief of the General Staff of the Armed Forces,Bajram Begaj,Q107422711,2020-07-29,male,1967-03-20,,Major General Bajram Begaj.png,Bajram Begaj
-Governor of the Bank of Albania,Gent Sejko,Q21073125,2015-02-05,male,2000,,,
+Governor of the Bank of Albania,Gent Sejko,Q21073125,2015-02-05,male,,,,

--- a/docs/leaders/albania/index.html
+++ b/docs/leaders/albania/index.html
@@ -429,7 +429,7 @@
                 
                 <ul>
                   <li>male</li>
-                  <li>born 2000</li>
+                  
                   <li>in office since 2015-02-05</li>
                   <li>
                     

--- a/docs/leaders/anguilla/current.csv
+++ b/docs/leaders/anguilla/current.csv
@@ -1,7 +1,7 @@
 position,person,personID,start,gender,DOB,DOD,image,enwiki
-Premier of Anguilla,Ellis Webster,Q98079363,2020-06-30,male,2000,,,Ellis Webster
+Premier of Anguilla,Ellis Webster,Q98079363,2020-06-30,male,,,,Ellis Webster
 Minister of Economic Development,Kyle Hodge,Q107772272,2020-03-13,,,,,
-Minister of Finance,Ellis Webster,Q98079363,2020-03-13,male,2000,,,Ellis Webster
+Minister of Finance,Ellis Webster,Q98079363,2020-03-13,male,,,,Ellis Webster
 Minister of Home Affairs,Kenneth Hodge,Q107772586,2020-03-13,,,,,
 Minister of Social Development,Dee-Ann Kentish-Rogers,Q55639564,2020-03-13,female,1993-01-13,,"Dee-Ann Kentish-Rogers, Commonwealth Games 2014 - Athletics Day 4 (14821413683) (cropped).jpg",Dee-Ann Kentish-Rogers
 Minister of MICUH,Haydn Hughes,Q107772438,2020-03-13,,,,,

--- a/docs/leaders/anguilla/index.html
+++ b/docs/leaders/anguilla/index.html
@@ -72,7 +72,7 @@
                 
                 <ul>
                   <li>male</li>
-                  <li>born 2000</li>
+                  
                   <li>in office since 2020-06-30</li>
                   <li>
                     <a href="https://en.wikipedia.org/wiki/Ellis_Webster"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>

--- a/docs/leaders/antigua-and-barbuda/current.csv
+++ b/docs/leaders/antigua-and-barbuda/current.csv
@@ -2,19 +2,19 @@ position,person,personID,start,gender,DOB,DOD,image,enwiki
 monarch,Elizabeth II,Q9682,1981-11-01,female,1926-04-21,,Queen Elizabeth II in March 2015.jpg,Elizabeth II
 Governor-General,Rodney Williams,Q17566330,2014-08-14,male,1947-11-02,,Governor General Of Antigua And Barbuda (37250652361) (cropped).jpg,Rodney Williams (governor-general)
 Prime Minister,Gaston Browne,Q17177542,2014-06-13,male,1967-02-09,,PM Gaston Browne (36764147103).jpg,Gaston Browne
-"Minister of Agriculture, Lands, Fisheries and Barbuda Affairs",Samantha Marshall,Q20192069,2020-01-20,female,2000-01-01,,,Samantha Marshall
-"Minister of Education, Science and Technology",Michael Sherwin Harris Browne,Q20171315,2018-03-22,male,2000,,,
+"Minister of Agriculture, Lands, Fisheries and Barbuda Affairs",Samantha Marshall,Q20192069,2020-01-20,female,,,,Samantha Marshall
+"Minister of Education, Science and Technology",Michael Sherwin Harris Browne,Q20171315,2018-03-22,male,,,,
 Minister of Finance,Gaston Browne,Q17177542,2018-03-22,male,1967-02-09,,PM Gaston Browne (36764147103).jpg,Gaston Browne
-Minister of Foreign Affairs,Paul Chet Greene,Q20172097,2018-03-22,male,2000-01-01,,,Paul Chet Greene
-"Minister of Health, Wellness & The Environment",Molwyn Joseph,Q16730448,2018-03-22,male,2000-01-01,,,Molwyn Joseph
+Minister of Foreign Affairs,Paul Chet Greene,Q20172097,2018-03-22,male,,,,Paul Chet Greene
+"Minister of Health, Wellness & The Environment",Molwyn Joseph,Q16730448,2018-03-22,male,,,,Molwyn Joseph
 "Minister for Housing, Lands and Urban Renewal",Maria Bird-Browne,Q100606338,2018-03-22,female,1991,,,Maria Bird-Browne
-"Minister of Information, Broadcasting, Telecommunications and Information Technology",Melford Nicholas,Q20850520,2018-03-22,male,2000-01-01,,,
-"Minister of Legal Affairs, Public Safety, and Labour",Steadroy Benjamin,Q7605192,2018-03-22,male,2000-01-01,,,Steadroy Benjamin
-"Minister of Public Utilities, Civil Aviation, Transportation",Robin Yearwood,Q7352892,2018-03-22,male,2000-01-01,,,Robin Yearwood
-Minister of Social Transformation and Human Resource Development,Samantha Marshall,Q20192069,2018-03-22,female,2000-01-01,,,Samantha Marshall
+"Minister of Information, Broadcasting, Telecommunications and Information Technology",Melford Nicholas,Q20850520,2018-03-22,male,,,,
+"Minister of Legal Affairs, Public Safety, and Labour",Steadroy Benjamin,Q7605192,2018-03-22,male,,,,Steadroy Benjamin
+"Minister of Public Utilities, Civil Aviation, Transportation",Robin Yearwood,Q7352892,2018-03-22,male,,,,Robin Yearwood
+Minister of Social Transformation and Human Resource Development,Samantha Marshall,Q20192069,2018-03-22,female,,,,Samantha Marshall
 "Minister of Sports, Culture, National Festivals and the Arts",Daryll Mathew,Q104634506,2018-03-22,male,,,,Daryll Mathew
 Minister of Tourism and Economic Development,Charles Fernandez,Q20171771,2018-03-22,male,1954-12-24,,Charles Max Fernandez.jpg,Charles Fernandez
 Minister of Works,Lennox Weston,Q108319069,2018-03-22,male,,,,
-Attorney General,Steadroy Benjamin,Q7605192,2018-03-22,male,2000-01-01,,,Steadroy Benjamin
+Attorney General,Steadroy Benjamin,Q7605192,2018-03-22,male,,,,Steadroy Benjamin
 Speaker of the House of Representatives,Gerald Watt,Q104642679,2014-06-25,male,1938-12-19,,,Gerald Watt
 President of the Senate,Alincia Williams-Grant,Q48417293,2014-06-25,female,,,,Alincia Williams-Grant

--- a/docs/leaders/antigua-and-barbuda/index.html
+++ b/docs/leaders/antigua-and-barbuda/index.html
@@ -123,7 +123,7 @@
                 
                 <ul>
                   <li>female</li>
-                  <li>born 2000-01-01</li>
+                  
                   <li>in office since 2020-01-20</li>
                   <li>
                     <a href="https://en.wikipedia.org/wiki/Samantha_Marshall"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>
@@ -140,7 +140,7 @@
                 
                 <ul>
                   <li>male</li>
-                  <li>born 2000</li>
+                  
                   <li>in office since 2018-03-22</li>
                   <li>
                     
@@ -157,7 +157,7 @@
                 
                 <ul>
                   <li>male</li>
-                  <li>born 2000-01-01</li>
+                  
                   <li>in office since 2018-03-22</li>
                   <li>
                     <a href="https://en.wikipedia.org/wiki/Paul_Chet_Greene"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>
@@ -174,7 +174,7 @@
                 
                 <ul>
                   <li>male</li>
-                  <li>born 2000-01-01</li>
+                  
                   <li>in office since 2018-03-22</li>
                   <li>
                     <a href="https://en.wikipedia.org/wiki/Molwyn_Joseph"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>
@@ -208,7 +208,7 @@
                 
                 <ul>
                   <li>male</li>
-                  <li>born 2000-01-01</li>
+                  
                   <li>in office since 2018-03-22</li>
                   <li>
                     
@@ -225,7 +225,7 @@
                 
                 <ul>
                   <li>male</li>
-                  <li>born 2000-01-01</li>
+                  
                   <li>in office since 2018-03-22</li>
                   <li>
                     <a href="https://en.wikipedia.org/wiki/Steadroy_Benjamin"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>
@@ -242,7 +242,7 @@
                 
                 <ul>
                   <li>male</li>
-                  <li>born 2000-01-01</li>
+                  
                   <li>in office since 2018-03-22</li>
                   <li>
                     <a href="https://en.wikipedia.org/wiki/Robin_Yearwood"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>

--- a/docs/leaders/australia/current.csv
+++ b/docs/leaders/australia/current.csv
@@ -77,7 +77,7 @@ Governor of the Reserve Bank,Philip Lowe,Q27922677,2016-09-18,male,1961-10-04,,P
 Chief of Air Force,Mel Hupfeld,Q6810731,2019-07-01,male,1962-03-07,,Mel Hupfeld.jpg,Mel Hupfeld
 Chief of Joint Operations,Greg Bilton,Q18639131,2019-07-01,male,1965-03-02,,Gregory C. Bilton.jpg,Greg Bilton
 Chief of Navy,Michael Noonan,Q16733451,2018-04-16,male,1966-12-13,,Michael J. Noonan in 2020.jpg,Michael Noonan (admiral)
-Chief of the Defence Force,Angus Campbell,Q5676860,2018-07-06,male,1901,,Angus Campbell.jpg,Angus Campbell (general)
+Chief of the Defence Force,Angus Campbell,Q5676860,2018-07-06,male,,,Angus Campbell.jpg,Angus Campbell (general)
 Governor of New South Wales,Margaret Beazley,Q6759174,2019-05-02,female,1951-07-23,,,Margaret Beazley
 Premier of New South Wales,Dominic Perrottet,Q5290616,2021-10-05,male,1982-09-21,,"CEBIT Australia - Day 2, The Hon Dominic Perrottet MP (2) (cropped).jpg",Dominic Perrottet
 Governor of Queensland,Jeannette Young,Q102105618,2021-11-01,female,1963,,"Jeannette Young, Chief Health Officer, Queensland Government, 2020 (cropped) 2.jpg",Jeannette Young

--- a/docs/leaders/australia/index.html
+++ b/docs/leaders/australia/index.html
@@ -1007,7 +1007,7 @@
                 <img class="bioimg" width="100" alt="image of Angus Campbell from Wikimedia Commons" src="https://commons.wikimedia.org/wiki/Special:FilePath/Angus%20Campbell.jpg?width=100" />
                 <ul>
                   <li>male</li>
-                  <li>born 1901</li>
+                  
                   <li>in office since 2018-07-06</li>
                   <li>
                     <a href="https://en.wikipedia.org/wiki/Angus_Campbell_(general)"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>

--- a/docs/leaders/canada/current.csv
+++ b/docs/leaders/canada/current.csv
@@ -4,7 +4,7 @@ Governor General,Mary Simon,Q6780723,2021-07-26,female,1947-08-21,,MarySimon.jpg
 Prime Minister,Justin Trudeau,Q3099714,2015-11-04,male,1971-12-25,,Trudeau visit White House for USMCA (cropped).jpg,Justin Trudeau
 Deputy Prime Minister,Chrystia Freeland,Q4492815,2019-11-20,female,1968-08-02,,Chrystia Freeland in Ukraine - 2017 (cropped).jpg,Chrystia Freeland
 Minister of Agriculture and Agri-Food,Marie-Claude Bibeau,Q21356553,2019-03-01,female,1970-03,,Marie-Claude Bibeau in Ukraine - 2018 (MUS0016) (cropped).jpg,Marie-Claude Bibeau
-Minister for the purposes of the Atlantic Canada Opportunities Agency Act,Ginette Petitpas Taylor,Q21714336,2021-10-26,female,1965,,GinettePT.jpg,Ginette Petitpas Taylor
+Minister for the purposes of the Atlantic Canada Opportunities Agency Act,Ginette Petitpas Taylor,Q21714336,2021-10-26,female,,,GinettePT.jpg,Ginette Petitpas Taylor
 Minister of Canadian Heritage,Pablo Rodríguez,Q3359999,2021-10-26,male,1967-06-21,,IC Pablo Rodriguez.JPG,Pablo Rodriguez (Canadian politician)
 Minister of Crown-Indigenous Relations,Marc Miller,Q22279214,2021-10-26,male,1971-03-12,,Canada Day Parade Montreal 2016 - 337a.jpg,Marc Miller (politician)
 Minister of Diversity and Inclusion and Youth,Ahmed Hussen,Q16211070,2021-10-26,male,1976,,Ahmed Hussen at the Toronto Caribbean Carnival - 2017 (36258275322).jpg,Ahmed Hussen
@@ -27,8 +27,8 @@ Minister of National Defence,Anita Anand,Q67442310,2021-10-26,female,1967,,Anita
 Minister of National Revenue,Diane Lebouthillier,Q21336098,2015-11-04,female,1959-02-05,,,Diane Lebouthillier
 Minister of Natural Resources,Jonathan Wilkinson,Q21716310,2021-10-26,male,1965-06-11,,Canadian Minister Jonathan Wilkinson (cropped).jpg,Jonathan Wilkinson
 Minister of Northern Affairs and National Resources,Dan Vandal,Q5214525,2019-11-20,male,1960-04-18,,Dan Vandal.jpg,Dan Vandal
-Minister of Public Safety and Emergency Preparedness,Bill Blair,Q4908168,2019-11-20,male,1954,,Bill Blair - 2012 (cropped).jpg,Bill Blair (politician)
 Minister of Public Safety and Emergency Preparedness,Marco Mendicino,Q21336208,2021-10-26,male,1973-07-28,,,Marco Mendicino
+Minister of Public Safety and Emergency Preparedness,Bill Blair,Q4908168,2019-11-20,male,1954,,Bill Blair - 2012 (cropped).jpg,Bill Blair (politician)
 Minister of Public Services and Procurement,Filomena Tassi,Q22770985,2021-10-26,female,1962,,Minister of Seniors Filomena Tassi (cropped).jpg,Filomena Tassi
 Minister of Rural Economic Development,Gudie Hutchings,Q22005483,2021-10-26,female,1959-09-01,,GudridHutchings.jpg,Gudie Hutchings
 Minister of Seniors,Kamal Khera,Q22278589,2021-10-26,female,1989-02-04,,Kamal Khaira 1.jpg,Kamal Khera
@@ -40,7 +40,7 @@ Minister of Veterans Affairs,Lawrence MacAulay,Q3219913,2019-03-01,male,1946-09-
 Minister responsible for the Economic Development Agency for the Regions of Quebec,Pascale St-Onge,Q108673849,2021-10-26,female,,,,Pascale St-Onge
 Minister responsible for the Federal Economic Development Initiative for Northern Ontario,Patty Hajdu,Q21573510,2021-10-26,female,1966-11-03,,"Patty Hajdu, 2016 (cropped).jpg",Patty Hajdu
 Minister responsible for the Federal Economic Development Agency for Southern Ontario,Helena Jaczek,Q5703595,2021-10-26,female,1950-11-05,,,Helena Jaczek
-Minister responsible for Official Languages,Ginette Petitpas Taylor,Q21714336,2021-10-26,female,1965,,GinettePT.jpg,Ginette Petitpas Taylor
+Minister responsible for Official Languages,Ginette Petitpas Taylor,Q21714336,2021-10-26,female,,,GinettePT.jpg,Ginette Petitpas Taylor
 Minister responsible for the Status of Women,Marci Ien,Q6757065,2021-10-26,female,1969-07-29,,,Marci Ien
 Associate Minister of Finance,Randy Boissonnault,Q21572842,2021-10-26,male,1970-07-14,,Randy Boissonnault.jpg,Randy Boissonnault
 Associate Minister of National Defence,Lawrence MacAulay,Q3219913,2019-03-01,male,1946-09-09,,Lawrence McAulay 01-14-2016.jpg,Lawrence MacAulay

--- a/docs/leaders/canada/index.html
+++ b/docs/leaders/canada/index.html
@@ -157,7 +157,7 @@
                 <img class="bioimg" width="100" alt="image of Ginette Petitpas Taylor from Wikimedia Commons" src="https://commons.wikimedia.org/wiki/Special:FilePath/GinettePT.jpg?width=100" />
                 <ul>
                   <li>female</li>
-                  <li>born 1965</li>
+                  
                   <li>in office since 2021-10-26</li>
                   <li>
                     <a href="https://en.wikipedia.org/wiki/Ginette_Petitpas_Taylor"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>
@@ -523,23 +523,6 @@
                 </ul>
               </div>
             </dd>
-            <dt>Minister of Public Safety and Emergency Preparedness<br />President of the Queen's Privy Council</dt>
-            <dd>
-              <span class="toggle"></span>
-              Bill Blair
-              <div class="bio">
-                <img class="bioimg" width="100" alt="image of Bill Blair from Wikimedia Commons" src="https://commons.wikimedia.org/wiki/Special:FilePath/Bill%20Blair%20-%202012%20(cropped).jpg?width=100" />
-                <ul>
-                  <li>male</li>
-                  <li>born 1954</li>
-                  <li>in office since 2019-11-20</li>
-                  <li>
-                    <a href="https://en.wikipedia.org/wiki/Bill_Blair_(politician)"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>
-                    <a href="https://www.wikidata.org/wiki/Q4908168"><img width="50" alt="Wikidata" src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/Wikidata-logo.svg/50px-Wikidata-logo.svg.png"></a>
-                  </li>
-                </ul>
-              </div>
-            </dd>
             <dt>Minister of Public Safety and Emergency Preparedness</dt>
             <dd>
               <span class="toggle"></span>
@@ -553,6 +536,23 @@
                   <li>
                     <a href="https://en.wikipedia.org/wiki/Marco_Mendicino"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>
                     <a href="https://www.wikidata.org/wiki/Q21336208"><img width="50" alt="Wikidata" src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/Wikidata-logo.svg/50px-Wikidata-logo.svg.png"></a>
+                  </li>
+                </ul>
+              </div>
+            </dd>
+            <dt>Minister of Public Safety and Emergency Preparedness<br />President of the Queen's Privy Council</dt>
+            <dd>
+              <span class="toggle"></span>
+              Bill Blair
+              <div class="bio">
+                <img class="bioimg" width="100" alt="image of Bill Blair from Wikimedia Commons" src="https://commons.wikimedia.org/wiki/Special:FilePath/Bill%20Blair%20-%202012%20(cropped).jpg?width=100" />
+                <ul>
+                  <li>male</li>
+                  <li>born 1954</li>
+                  <li>in office since 2019-11-20</li>
+                  <li>
+                    <a href="https://en.wikipedia.org/wiki/Bill_Blair_(politician)"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>
+                    <a href="https://www.wikidata.org/wiki/Q4908168"><img width="50" alt="Wikidata" src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/Wikidata-logo.svg/50px-Wikidata-logo.svg.png"></a>
                   </li>
                 </ul>
               </div>

--- a/docs/leaders/jersey/current.csv
+++ b/docs/leaders/jersey/current.csv
@@ -11,7 +11,7 @@ Minister for Home Affairs,Gregory Guida,Q107614361,2018-01-01,,,,,
 Minister for Housing and Communities,Russell Labey,Q106961057,2018-01-01,male,,,,
 Minister for Infrastructure,Kevin Lewis,Q12061148,2018-01-01,male,,,Kevin Charles Lewis in 2012.JPG,Kevin C. Lewis
 Minister for International Development,Carolyn Labey,Q5045403,2018-01-01,female,,,Assèrmentâtion des Membres d's Êtats 2011 Saint Hélyi Jèrri 11.jpg,Carolyn Labey
-Minister for Social Security,Judy Martin,Q16732060,2018-01-01,female,2000-01-01,,,Judy Martin (politician)
+Minister for Social Security,Judy Martin,Q16732060,2018-01-01,female,,,,Judy Martin (politician)
 Minister for the Environment,John Young,Q107614343,2018-01-01,,,,,
 Minister for Treasury and Resources,Susan Pinel,Q16734551,2018-01-01,female,,,,Susan Pinel
 Assistant Minister for Social Security,Scott Wickenden,Q107614302,2018-01-01,,,,,

--- a/docs/leaders/jersey/index.html
+++ b/docs/leaders/jersey/index.html
@@ -242,7 +242,7 @@
                 
                 <ul>
                   <li>female</li>
-                  <li>born 2000-01-01</li>
+                  
                   <li>in office since 2018-01-01</li>
                   <li>
                     <a href="https://en.wikipedia.org/wiki/Judy_Martin_(politician)"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>

--- a/docs/leaders/niue/current.csv
+++ b/docs/leaders/niue/current.csv
@@ -4,4 +4,4 @@ Minister for Central Agencies & Commercial Agencies,Dalton Tagelagi,Q19876617,20
 Minister for Infrastructure and Finance,Crossley Tatui,Q96204345,2020-06-11,male,,,,Crossley Tatui
 Minister of Natural Resources,Mona Ainuu,Q42704251,2020-06-11,female,,,Mona Ainu’u 2017.jpg,Mona Ainuu
 Minister of Social Services,Sauni Tongatule,Q97453993,2020-06-11,male,,,,Sauni Tongatule
-Speaker of the Assembly,Hima Douglas,Q5764847,2020-06-11,male,1940,,,Hima Douglas
+Speaker of the Assembly,Hima Douglas,Q5764847,2020-06-11,male,,,,Hima Douglas

--- a/docs/leaders/niue/index.html
+++ b/docs/leaders/niue/index.html
@@ -140,7 +140,7 @@
                 
                 <ul>
                   <li>male</li>
-                  <li>born 1940</li>
+                  
                   <li>in office since 2020-06-11</li>
                   <li>
                     <a href="https://en.wikipedia.org/wiki/Hima_Douglas"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>


### PR DESCRIPTION
If a DOB is at a precision less than a day (e.g. a decade or century), omit it for now.

It's possible that later we'll try to include some of these in a different way, but currently they're just misleading.