### PR TITLE
Tonga: Lord Ma'afu has died

### DIFF
--- a/docs/leaders/tonga/current.csv
+++ b/docs/leaders/tonga/current.csv
@@ -1,9 +1,9 @@
 position,person,personID,start,gender,DOB,DOD,image,enwiki
 monarch,Tupou VI of Tonga,Q208497,2012-03-18,male,1959-07-12,,Ulukalala Lavaka Ata.jpg,Tupou VI
 Prime Minister,Pohiva Tuʻiʻonetoa,Q48778102,2019-10-08,male,1961-06-30,,Pohiva Tuʻiʻonetoa (cropped).jpg,Pohiva Tuʻiʻonetoa
-Deputy Prime Minister,Lord Maʻafu,Q3485136,2017-09-05,male,1955,,Lord Ma’afu.jpg,Maʻafu Tukuiʻaulahi
+Deputy Prime Minister,Lord Maʻafu,Q3485136,2017-09-05,male,1955,2021-12-12,Lord Ma’afu.jpg,Maʻafu Tukuiʻaulahi
 "Minister for Agriculture, Food, and Forests","Malakai Fakatoufifita, 15th Lord Tuʻilakepa",Q3567558,2019-10-08,male,,,Lord Tu’ilakepa and Lord Nuku (Cropped 1).jpg,Malakai Fakatoufifita
-Minister of Defence,Lord Maʻafu,Q3485136,2019-10-09,male,1955,,Lord Ma’afu.jpg,Maʻafu Tukuiʻaulahi
+Minister of Defence,Lord Maʻafu,Q3485136,2019-10-09,male,1955,2021-12-12,Lord Ma’afu.jpg,Maʻafu Tukuiʻaulahi
 Minister for Education and Training,Siaosi Sovaleni,Q19631293,2019-10-10,male,1970-02-28,,Siaosi Sovaleni 2017.jpg,Siaosi Sovaleni
 Minister for the Environment and Climate Change,Poasi Tei,Q96479418,2018-01-04,male,1967-10-04,,,Poasi Tei
 Minister of Finance,Tevita Lavemaau,Q96574147,2019-10-10,male,1960-08-30,,,Tevita Lavemaau
@@ -11,7 +11,7 @@ Minister of Health,‘Amelia Afuha’amango Tu’ipulotu,Q96314730,2019-10-10,fe
 Minister of Infrastructure and Tourism,‘Akosita Lavulavu,Q28910910,2019-10-10,female,1984-09-11,,Akosita Lavulavu 2016.jpg,ʻAkosita Lavulavu
 Minister for Internal Affairs,Vatau Hui,Q96479582,2019-10-10,male,1970-06-02,,,Vatau Hui
 Minister of Justice,Samiu Vaipulu,Q3470867,2021-01-25,male,1952-12-24,,,Samiu Vaipulu
-"Minister for Lands, Survey, Natural Resources",Lord Maʻafu,Q3485136,2011-01-04,male,1955,,Lord Ma’afu.jpg,Maʻafu Tukuiʻaulahi
+"Minister for Lands, Survey, Natural Resources",Lord Maʻafu,Q3485136,2011-01-04,male,1955,2021-12-12,Lord Ma’afu.jpg,Maʻafu Tukuiʻaulahi
 Minister of Police,Lord Nuku,Q109918746,2019-10-08,male,,,Lord Tu’ilakepa and Lord Nuku (Cropped 2).jpg,
 Minister for Revenue and Customs,Tevita Lavemaau,Q96574147,2019-10-10,male,1960-08-30,,,Tevita Lavemaau
 Minister for Trade and Economic Development,Tatafu Moeaki,Q109661097,2021-01-25,male,1972-12-08,,,Tatafu Moeaki

--- a/docs/leaders/tonga/index.html
+++ b/docs/leaders/tonga/index.html
@@ -98,13 +98,13 @@
             </dd>
             <dt>Deputy Prime Minister<br />Minister of Defence<br />Minister for Lands, Survey, Natural Resources</dt>
             <dd>
-              <span class="toggle">Lord Maʻafu</span>
+              <span class="toggle"><s>Lord Maʻafu</s></span>
               <div class="bio">
                 <img class="bioimg" width="100" alt="image of Lord Maʻafu from Wikimedia Commons" src="https://commons.wikimedia.org/wiki/Special:FilePath/Lord%20Ma’afu.jpg?width=100" />
                 <ul>
                   <li>male</li>
                   <li>born 1955</li>
-                  <li>in office since 2017-09-05</li>
+<li>died 2021-12-12</li>                  <li>in office since 2017-09-05</li>
                   <li>
                     <a href="https://en.wikipedia.org/wiki/Maʻafu_Tukuiʻaulahi"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a>
                     <a href="https://www.wikidata.org/wiki/Q3485136"><img width="50" alt="Wikidata" src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/Wikidata-logo.svg/50px-Wikidata-logo.svg.png"></a>

--- a/template/index.erb
+++ b/template/index.erb
@@ -68,12 +68,13 @@
         <%- table.group_by { |row| row[:personid] }.each do |person, positions| -%>
             <dt><%= positions.map { |mem| mem[:position] }.join('<br />') %></dt>
             <dd>
-              <span class="toggle"><%= positions.first[:person] %></span>
+              <span class="toggle"><% if positions.first[:dod].to_s.empty? %><%= positions.first[:person] %><% else %><s><%= positions.first[:person] %></s><% end %></span>
               <div class="bio">
                 <% unless positions.first[:image].to_s.empty? %><img class="bioimg" width="100" alt="image of <%= positions.first[:person] %> from Wikimedia Commons" src="https://commons.wikimedia.org/wiki/Special:FilePath/<%= positions.first[:image].gsub(' ','%20').gsub('"','%22') %>?width=100" /><% end %>
                 <ul>
                   <% unless positions.first[:gender].to_s.empty? %><li><%= positions.first[:gender] %></li><% end %>
                   <% unless positions.first[:dob].to_s.empty? %><li>born <%= positions.first[:dob] %></li><% end %>
+                  <%- unless positions.first[:dod].to_s.empty? %><li>died <%= positions.first[:dod] %></li><% end -%>
                   <li>in office since <%= positions.first[:start] %></li>
                   <li>
                     <% unless positions.first[:enwiki].to_s.empty? %><a href="https://en.wikipedia.org/wiki/<%= positions.first[:enwiki].gsub(' ', '_') %>"><img width="32" alt="Wikipedia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg/32px-Cib-wikipedia_%28CoreUI_Icons_v1.0.0%29.svg.png" /></a><% end %>


### PR DESCRIPTION
Between dying and someone new in the position we sometimes want to continue displayting the former officeholder; in such cases display the name in strikethrough, and also display the date of death.

![Screenshot 2021-12-13 at 08 09 24](https://user-images.githubusercontent.com/57483/145761163-8b8381aa-bffd-4a9e-8930-293e351d9d1b.png)
![Screenshot 2021-12-13 at 08 09 33](https://user-images.githubusercontent.com/57483/145761156-16628f7e-9a6d-4494-8a89-2c468e0fe48c.png)

